### PR TITLE
Gradle fixes (disable signing if not publishing)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,13 @@ subprojects {
 		archives docJar
 		archives sourcesJar
 	}
-        
-        signing.onlyIf {
-		project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')
-	}
 
 	signing {
 		sign configurations.archives
+	}
+        
+        signArchives.onlyIf {
+		project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')
 	}
 
 	uploadArchives.onlyIf {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ subprojects {
 		archives docJar
 		archives sourcesJar
 	}
+        
+        signing.onlyIf {
+		project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')
+	}
 
 	signing {
 		sign configurations.archives


### PR DESCRIPTION
To prevent signing errors I applied the same predicate to the `signArchives` as to the `uploadArchives` task. Now it's possible to build without having the sonatype credentials, keys etc.
