### PR TITLE
Fix css issue with extended components

### DIFF
--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTextField.java
@@ -80,7 +80,7 @@ public class CalendarTextField extends Control
 	{
 		// setup the CSS
 		// the -fx-skin attribute in the CSS sets which Skin class is used
-		this.getStyleClass().add(this.getClass().getSimpleName());
+		this.getStyleClass().add(CalendarTextField.class.getSimpleName());
 		
 		// this is apparently needed for good focus behavior
 		setFocusTraversable(false);

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimePicker.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimePicker.java
@@ -64,7 +64,7 @@ public class CalendarTimePicker extends Control
 	{
 		// setup the CSS
 		// the -fx-skin attribute in the CSS sets which Skin class is used
-		this.getStyleClass().add(this.getClass().getSimpleName());
+		this.getStyleClass().add(CalendarTimePicker.class.getSimpleName());
 	}
 
 	/**

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimeTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimeTextField.java
@@ -76,7 +76,7 @@ public class CalendarTimeTextField extends Control
 	{
 		// setup the CSS
 		// the -fx-skin attribute in the CSS sets which Skin class is used
-		this.getStyleClass().add(this.getClass().getSimpleName());
+		this.getStyleClass().add(CalendarTimeTextField.class.getSimpleName());
 		
 		// this is apparently needed for good focus behavior
 		setFocusTraversable(false);

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/ListSpinner.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/ListSpinner.java
@@ -154,7 +154,7 @@ public class ListSpinner<T> extends Control
 	{
 		// setup the CSS
 		// the -fx-skin attribute in the CSS sets which Skin class is used
-		this.getStyleClass().add(this.getClass().getSimpleName());
+		this.getStyleClass().add(ListSpinner.class.getSimpleName());
 		
 		// react to changes of the value
 		this.valueObjectProperty.addListener(new ChangeListener<T>()
@@ -232,7 +232,7 @@ public class ListSpinner<T> extends Control
 	 */
 	@Override protected String getUserAgentStylesheet()
 	{
-		return this.getClass().getResource("/jfxtras/internal/scene/control/" + this.getClass().getSimpleName() + ".css").toExternalForm();
+		return this.getClass().getResource("/jfxtras/internal/scene/control/" + ListSpinner.class.getSimpleName() + ".css").toExternalForm();
 	}
 	
 	// ==================================================================================================================

--- a/jfxtras-controls/src/test/java/jfxtras/scene/control/test/AllTests.java
+++ b/jfxtras-controls/src/test/java/jfxtras/scene/control/test/AllTests.java
@@ -7,12 +7,16 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ ListSpinnerArrowTest.class
               , ListSpinnerEditableTest.class
+              , ListSpinnerExtendedTest.class
               , CalendarTimePickerTest.class
               , CalendarTimePickerFXMLTest.class
+              , CalendarTimePickerExtendedTest.class
               , CalendarPickerTest.class
               , CalendarPickerFXMLTest.class
+              , CalendarPickerExtendedTest.class
               , CalendarTextFieldTest.class
 	          , CalendarTextFieldFXMLTest.class
+              , CalendarTextFieldExtendedTest.class
 	          , LocalDatePickerTest.class
 	          , LocalDatePickerFXMLTest.class
 	          , LocalDateTimePickerTest.class 

--- a/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarPickerExtendedTest.java
+++ b/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarPickerExtendedTest.java
@@ -1,0 +1,63 @@
+package jfxtras.scene.control.test;
+
+import javafx.collections.FXCollections;
+import javafx.scene.Parent;
+import javafx.scene.layout.Pane;
+import jfxtras.scene.control.CalendarPicker;
+import jfxtras.scene.layout.VBox;
+import jfxtras.test.JFXtrasGuiTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import java.util.List;
+
+/**
+ * Created by bblonski on 9/12/14.
+ */
+public class CalendarPickerExtendedTest extends JFXtrasGuiTest {
+
+    private static Pane root;
+    final private List<String> expected = FXCollections.observableArrayList("CalendarPicker");
+    private volatile boolean pass = true;
+
+    @Test
+    public void TestAnonymousCalendarPicker() throws Exception {
+        final CalendarPicker spinner = new CalendarPicker() {};
+        Assert.assertEquals(expected, spinner.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                root.getChildren().add(spinner);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Test
+    public void TestExtendedCalendarPicker() throws Exception {
+        final TestCalendarPicker picker = new TestCalendarPicker();
+        Assert.assertEquals(expected, picker.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                    root.getChildren().add(picker);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Override
+    protected Parent getRootNode() {
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                pass = false;
+            }
+        });
+        root = new VBox();
+        return root;
+    }
+
+    private class TestCalendarPicker extends CalendarPicker {};
+}

--- a/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarTextFieldExtendedTest.java
+++ b/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarTextFieldExtendedTest.java
@@ -1,0 +1,63 @@
+package jfxtras.scene.control.test;
+
+import javafx.collections.FXCollections;
+import javafx.scene.Parent;
+import javafx.scene.layout.Pane;
+import jfxtras.scene.control.CalendarTextField;
+import jfxtras.scene.layout.VBox;
+import jfxtras.test.JFXtrasGuiTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import java.util.List;
+
+/**
+ * Created by bblonski on 9/12/14.
+ */
+public class CalendarTextFieldExtendedTest extends JFXtrasGuiTest {
+
+    private static Pane root;
+    final private List<String> expected = FXCollections.observableArrayList("CalendarTextField");
+    private volatile boolean pass = true;
+
+    @Test
+    public void TestAnonymousCalendarPicker() throws Exception {
+        final CalendarTextField spinner = new CalendarTextField() {};
+        Assert.assertEquals(expected, spinner.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                root.getChildren().add(spinner);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Test
+    public void TestExtendedCalendarPicker() throws Exception {
+        final TestCalendarTextField picker = new TestCalendarTextField();
+        Assert.assertEquals(expected, picker.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                    root.getChildren().add(picker);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Override
+    protected Parent getRootNode() {
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                pass = false;
+            }
+        });
+        root = new VBox();
+        return root;
+    }
+
+    private class TestCalendarTextField extends CalendarTextField {};
+}

--- a/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarTimePickerExtendedTest.java
+++ b/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarTimePickerExtendedTest.java
@@ -1,0 +1,63 @@
+package jfxtras.scene.control.test;
+
+import javafx.collections.FXCollections;
+import javafx.scene.Parent;
+import javafx.scene.layout.Pane;
+import jfxtras.scene.control.CalendarTimePicker;
+import jfxtras.scene.layout.VBox;
+import jfxtras.test.JFXtrasGuiTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import java.util.List;
+
+/**
+ * Created by bblonski on 9/12/14.
+ */
+public class CalendarTimePickerExtendedTest extends JFXtrasGuiTest {
+
+    private static Pane root;
+    final private List<String> expected = FXCollections.observableArrayList("CalendarTimePicker");
+    private volatile boolean pass = true;
+
+    @Test
+    public void TestAnonymousCalendarPicker() throws Exception {
+        final CalendarTimePicker spinner = new CalendarTimePicker() {};
+        Assert.assertEquals(expected, spinner.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                root.getChildren().add(spinner);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Test
+    public void TestExtendedCalendarPicker() throws Exception {
+        final TestCalendarTimePicker picker = new TestCalendarTimePicker();
+        Assert.assertEquals(expected, picker.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                    root.getChildren().add(picker);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Override
+    protected Parent getRootNode() {
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                pass = false;
+            }
+        });
+        root = new VBox();
+        return root;
+    }
+
+    private class TestCalendarTimePicker extends CalendarTimePicker {};
+}

--- a/jfxtras-controls/src/test/java/jfxtras/scene/control/test/ListSpinnerExtendedTest.java
+++ b/jfxtras-controls/src/test/java/jfxtras/scene/control/test/ListSpinnerExtendedTest.java
@@ -1,0 +1,63 @@
+package jfxtras.scene.control.test;
+
+import javafx.collections.FXCollections;
+import javafx.scene.Parent;
+import javafx.scene.layout.Pane;
+import jfxtras.scene.control.ListSpinner;
+import jfxtras.scene.layout.VBox;
+import jfxtras.test.JFXtrasGuiTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.loadui.testfx.utils.FXTestUtils;
+
+import java.util.List;
+
+/**
+ * Created by bblonski on 9/12/14.
+ */
+public class ListSpinnerExtendedTest extends JFXtrasGuiTest {
+
+    private static Pane root;
+    final private List<String> expected = FXCollections.observableArrayList("ListSpinner");
+    private volatile boolean pass = true;
+
+    @Test
+    public void TestAnonymousListSpinner() throws Exception {
+        final ListSpinner spinner = new ListSpinner() {};
+        Assert.assertEquals(expected, spinner.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                root.getChildren().add(spinner);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Test
+    public void TestExtendedListSpinner() throws Exception {
+        final TestListSpinner spinner = new TestListSpinner();
+        Assert.assertEquals(expected, spinner.getStyleClass());
+        FXTestUtils.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                    root.getChildren().add(spinner);
+            }
+        }, 1);
+        Assert.assertTrue(pass);
+    }
+
+    @Override
+    protected Parent getRootNode() {
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                pass = false;
+            }
+        });
+        root = new VBox();
+        return root;
+    }
+
+    private class TestListSpinner extends ListSpinner {};
+}


### PR DESCRIPTION
An issue with how class names were being resolved caused several issues with CSS if the ListSpinner or Calendar\* controls were exteded.  Here's a fix with unit tests.  Not sure why so many line endings are different.
