### PR TITLE
Adding "pickerShowing" property on all TextFields in order to control mo...

### DIFF
--- a/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/CalendarTextFieldSkin.java
+++ b/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/CalendarTextFieldSkin.java
@@ -1,7 +1,7 @@
 /**
  * CalendarTextFieldSkin.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -36,12 +36,12 @@ import java.util.Date;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.scene.control.SkinBase;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
@@ -67,6 +67,13 @@ import jfxtras.util.NodeUtil;
  */
 public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 {
+    
+    private TextField textField = null;
+    private ImageView imageView = null;
+    private GridPane gridPane = null;
+    final public BooleanProperty focusForwardingProperty = new SimpleBooleanProperty();
+    private final Popup popup = new Popup();
+    private CalendarPicker calendarPicker;
 	// ==================================================================================================================
 	// CONSTRUCTOR
 	
@@ -86,6 +93,9 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 	{
 		// setup component
 		createNodes();
+                
+                //We initiate the popup here
+                setupPopup();
 		
 		// react to value changes in the model
 		getSkinnable().calendarProperty().addListener( (observableValue, oldValue, newValue) -> { refreshValue(); });
@@ -97,6 +107,28 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 		
 		// focus
 		initFocusSimulation();
+                
+            /**
+             * If the popup is showing/hiding, we must notify the property of
+             * the CalendarTextField so that they are always in sync.
+             */
+            popup.showingProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean showing) -> {
+                getSkinnable().setPickerShowing(showing);
+            });
+
+            /**
+             * If the user is triggering the property, we must show the popup.
+             * We cannot bind the property directly to the popup because the
+             * popup property is read only. MoreOver, we want to show the popup
+             * next to the TextField, that's why we need to call showPopup();
+             */
+            getSkinnable().pickerShowingProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean showing) -> {
+                if (showing) {
+                    showPopup();
+                } else {
+                    popup.hide();
+                }
+            });
 	}
 	
 	/*
@@ -188,7 +220,7 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 			if (textField.focusedProperty().get() == true) {
 				parse();
 			}
-			showPopup(evt);
+                        getSkinnable().setPickerShowing(true);
 		});
 		
 		// construct a gridpane: one row, two columns
@@ -204,12 +236,8 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 		getSkinnable().getStyleClass().add(this.getClass().getSimpleName()); // always add self as style class, because CSS should relate to the skin not the control
 		getChildren().add(gridPane);
 	}
-	private TextField textField = null;
-	private ImageView imageView = null;
-	private GridPane gridPane = null;
-	final public BooleanProperty focusForwardingProperty = new SimpleBooleanProperty();
-	
-	/**
+
+        /**
 	 * parse the contents that was typed in the textfield
 	 */
 	private void parse() {
@@ -313,13 +341,10 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 		} 
 	}
 	
-	/*
-	 * 
-	 */
-	private void showPopup(MouseEvent evt)
-	{
-		// create a picker
-		CalendarPicker calendarPicker = new CalendarPicker();
+        
+        private void setupPopup(){
+            // create a picker
+		calendarPicker = new CalendarPicker();
 		calendarPicker.setMode(CalendarPicker.Mode.SINGLE);
 		calendarPicker.localeProperty().set(getSkinnable().localeProperty().get());
 		calendarPicker.allowNullProperty().set(getSkinnable().allowNullProperty().get());
@@ -352,10 +377,9 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 //	                getScene().getRoot().impl_processCSS(true);
 //	            }
 //	        };
-		Popup lPopup = new Popup();
-		lPopup.setAutoFix(true);
-		lPopup.setAutoHide(true);
-		lPopup.setHideOnEscape(true);
+                popup.setAutoFix(true);
+                popup.setAutoHide(true);
+                popup.setHideOnEscape(true);
 		BorderPane lBorderPane = new BorderPane() {
 			// As of 1.8.0_40 CSS files are added in the scope of a control, the popup does not fall under the control, so the stylesheet must be reapplied 
 			// When JFxtras is based on 1.8.0_40+: @Override 
@@ -365,7 +389,7 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 		};
 		lBorderPane.getStyleClass().add(this.getClass().getSimpleName() + "_popup");
 		lBorderPane.setCenter(calendarPicker);
-		calendarPicker.showTimeProperty().set( getSkinnable().getShowTime() );
+		calendarPicker.showTimeProperty().bind(getSkinnable().showTimeProperty());
 		
 		// because the Java 8 DateTime classes use the CalendarPicker, we need to add some specific CSS classes here to support seamless CSS
 		if (getSkinnable().getStyleClass().contains(LocalDateTextField.class.getSimpleName())) {
@@ -386,7 +410,7 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 			lAcceptIconImageView.setPickOnBounds(true);
 			lAcceptIconImageView.setOnMouseClicked( (mouseEvent) ->  {
 				getSkinnable().calendarProperty().set(calendarPicker.calendarProperty().get());
-				lPopup.hide(); 
+				popup.hide(); 
 			});
 			lVBox.add(lAcceptIconImageView);
 			
@@ -394,20 +418,20 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 			lCloseIconImageView.getStyleClass().addAll("close-icon");
 			lCloseIconImageView.setPickOnBounds(true);
 			lCloseIconImageView.setOnMouseClicked( (mouseEvent) ->  {
-				lPopup.hide(); 
+				popup.hide(); 
 			});
 			lVBox.add(lCloseIconImageView);
 		}
 		
 		// if a value is selected in date mode, immediately close the popup
 		calendarPicker.calendarProperty().addListener( (observable) -> {
-			if (lPopup != null &&  getSkinnable().getShowTime() == false && lPopup.isShowing()) {
-				lPopup.hide(); 
+			if (popup != null &&  getSkinnable().getShowTime() == false && popup.isShowing()) {
+				popup.hide(); 
 			}
 		});
 
 		// when the popup is hidden 
-		lPopup.setOnHiding( (windowEvent) -> {
+		popup.setOnHiding( (windowEvent) -> {
 			// and time is not shown, the value must be set into the textfield
 			if ( getSkinnable().getShowTime() == false) {
 				getSkinnable().calendarProperty().set(calendarPicker.calendarProperty().get());
@@ -417,13 +441,22 @@ public class CalendarTextFieldSkin extends SkinBase<CalendarTextField>
 		});
 		
 		// add to popup
-		lPopup.getContent().add(lBorderPane);
+		popup.getContent().setAll(lBorderPane);
 		
 		// show it just below the textfield
 		textField.setDisable(true);
-		lPopup.show(textField, NodeUtil.screenX(getSkinnable()), NodeUtil.screenY(getSkinnable()) + textField.getHeight());
+		
+        }
 
-		// move the focus over		
-		calendarPicker.requestFocus(); // TODO: not working
-	}
+    /**
+     * This is either called by the user clicking on the button, or
+     * programmaticaly with {@link CalendarTextField#setPickerShowing(boolean)
+     * }.
+     */
+    private void showPopup() {
+        popup.show(textField, NodeUtil.screenX(getSkinnable()), NodeUtil.screenY(getSkinnable()) + textField.getHeight());
+        
+        // move the focus over		
+        calendarPicker.requestFocus(); // TODO: not working
+    }
 }

--- a/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/LocalDateTextFieldSkin.java
+++ b/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/LocalDateTextFieldSkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -67,6 +67,7 @@ public class LocalDateTextFieldSkin extends SkinBase<LocalDateTextField>
 		calendarTextField.styleProperty().bindBidirectional( getSkinnable().styleProperty() );
 		calendarTextField.tooltipProperty().bindBidirectional( getSkinnable().tooltipProperty() ); 
 		calendarTextField.textProperty().bindBidirectional( getSkinnable().textProperty() ); 
+                calendarTextField.pickerShowingProperty().bindBidirectional(getSkinnable().pickerShowingProperty());
 
 		// bind it up
 		calendarTextField.localeProperty().bindBidirectional( getSkinnable().localeProperty() );

--- a/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/LocalDateTimeTextFieldSkin.java
+++ b/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/LocalDateTimeTextFieldSkin.java
@@ -1,7 +1,7 @@
 /**
  * LocalDateTimeTextFieldSkin.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -70,6 +70,7 @@ public class LocalDateTimeTextFieldSkin extends SkinBase<LocalDateTimeTextField>
 		calendarTextField.styleProperty().bindBidirectional( getSkinnable().styleProperty() );
 		calendarTextField.tooltipProperty().bindBidirectional(getSkinnable().tooltipProperty()); 
 		calendarTextField.textProperty().bindBidirectional( getSkinnable().textProperty() ); 
+                calendarTextField.pickerShowingProperty().bindBidirectional(getSkinnable().pickerShowingProperty());
 
 		// bind it up
 		calendarTextField.localeProperty().bindBidirectional( getSkinnable().localeProperty() );

--- a/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/LocalTimeTextFieldSkin.java
+++ b/jfxtras-controls/src/main/java/jfxtras/internal/scene/control/skin/LocalTimeTextFieldSkin.java
@@ -1,7 +1,7 @@
 /**
  * LocalTimeTextFieldSkin.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -71,6 +71,7 @@ public class LocalTimeTextFieldSkin extends SkinBase<LocalTimeTextField>
 		calendarTimeTextField.getStyleClass().addAll(getSkinnable().getStyleClass());
 		calendarTimeTextField.styleProperty().bindBidirectional( getSkinnable().styleProperty() );
 		calendarTimeTextField.tooltipProperty().bindBidirectional( getSkinnable().tooltipProperty() ); 
+                calendarTimeTextField.pickerShowingProperty().bindBidirectional(getSkinnable().pickerShowingProperty());
 
 		// bind it up
 		calendarTimeTextField.localeProperty().bindBidirectional( getSkinnable().localeProperty() );

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTextField.java
@@ -249,37 +249,15 @@ public class CalendarTextField extends Control
 	public void setText(String value) { textObjectProperty.set(value); }
 	public CalendarTextField withText(String value) { setText(value); return this; }
 
-    
-    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
-
-    
-    /**
+     /**
      * Represents the current state of the Picker popup, and whether it is
      * currently visible on screen.
-     *
-     * @return
      */
-    public BooleanProperty pickerShowingProperty() {
-        return pickerShowingProperty;
-    }
-
-    /**
-     * Allow to show/hide the Picker.
-     *
-     * @param value
-     */
-    public void setPickerShowing(boolean value) {
-        pickerShowingProperty.set(value);
-    }
-
-    /**
-     * Return true if the Picker is currently shown.
-     *
-     * @return
-     */
-    public boolean isPickerShowing() {
-        return pickerShowingProperty.get();
-    }
+    public BooleanProperty pickerShowingProperty() { return pickerShowingProperty; }
+    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+    public boolean isPickerShowing() { return pickerShowingProperty.get(); }
+    public void setPickerShowing(boolean value) { pickerShowingProperty.set(value); }
+    
 	// ==================================================================================================================
 	// EVENTS
 	

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTextField.java
@@ -1,7 +1,7 @@
 /**
  * CalendarTextField.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -43,7 +43,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
@@ -251,6 +250,36 @@ public class CalendarTextField extends Control
 	public CalendarTextField withText(String value) { setText(value); return this; }
 
     
+    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+
+    
+    /**
+     * Represents the current state of the Picker popup, and whether it is
+     * currently visible on screen.
+     *
+     * @return
+     */
+    public BooleanProperty pickerShowingProperty() {
+        return pickerShowingProperty;
+    }
+
+    /**
+     * Allow to show/hide the Picker.
+     *
+     * @param value
+     */
+    public void setPickerShowing(boolean value) {
+        pickerShowingProperty.set(value);
+    }
+
+    /**
+     * Return true if the Picker is currently shown.
+     *
+     * @return
+     */
+    public boolean isPickerShowing() {
+        return pickerShowingProperty.get();
+    }
 	// ==================================================================================================================
 	// EVENTS
 	

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimeTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimeTextField.java
@@ -1,7 +1,7 @@
 /**
  * CalendarTimeTextField.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -36,9 +36,11 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
+import javafx.beans.property.BooleanProperty;
 
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
@@ -188,6 +190,35 @@ public class CalendarTimeTextField extends Control
 	public CalendarTimeTextField withDateFormat(ObservableList<DateFormat> value) { setDateFormats(value); return this; }
 
 
+       final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+
+    /**
+     * Represents the current state of the Picker popup, and whether it is
+     * currently visible on screen.
+     *
+     * @return
+     */
+    public BooleanProperty pickerShowingProperty() {
+        return pickerShowingProperty;
+    }
+
+    /**
+     * Allow to show/hide the Picker.
+     *
+     * @param value
+     */
+    public void setPickerShowing(boolean value) {
+        pickerShowingProperty.set(value);
+    }
+
+    /**
+     * Return true if the Picker is currently shown.
+     *
+     * @return
+     */
+    public boolean isPickerShowing() {
+        return pickerShowingProperty.get();
+    }
 	// ==================================================================================================================
 	// EVENTS
 	

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimeTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/CalendarTimeTextField.java
@@ -190,35 +190,14 @@ public class CalendarTimeTextField extends Control
 	public CalendarTimeTextField withDateFormat(ObservableList<DateFormat> value) { setDateFormats(value); return this; }
 
 
-       final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
-
-    /**
+       /**
      * Represents the current state of the Picker popup, and whether it is
      * currently visible on screen.
-     *
-     * @return
      */
-    public BooleanProperty pickerShowingProperty() {
-        return pickerShowingProperty;
-    }
-
-    /**
-     * Allow to show/hide the Picker.
-     *
-     * @param value
-     */
-    public void setPickerShowing(boolean value) {
-        pickerShowingProperty.set(value);
-    }
-
-    /**
-     * Return true if the Picker is currently shown.
-     *
-     * @return
-     */
-    public boolean isPickerShowing() {
-        return pickerShowingProperty.get();
-    }
+    public BooleanProperty pickerShowingProperty() { return pickerShowingProperty; }
+    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+    public boolean isPickerShowing() { return pickerShowingProperty.get(); }
+    public void setPickerShowing(boolean value) { pickerShowingProperty.set(value); }
 	// ==================================================================================================================
 	// EVENTS
 	

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTextField.java
@@ -191,35 +191,14 @@ public class LocalDateTextField extends Control
 	public LocalDateTextField withText(String value) { setText(value); return this; }
 
         
-        final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
-
-   /**
+        /**
      * Represents the current state of the Picker popup, and whether it is
      * currently visible on screen.
-     *
-     * @return
      */
-    public BooleanProperty pickerShowingProperty() {
-        return pickerShowingProperty;
-    }
-
-    /**
-     * Allow to show/hide the Picker.
-     *
-     * @param value
-     */
-    public void setPickerShowing(boolean value) {
-        pickerShowingProperty.set(value);
-    }
-
-    /**
-     * Return true if the Picker is currently shown.
-     *
-     * @return
-     */
-    public boolean isPickerShowing() {
-        return pickerShowingProperty.get();
-    }
+    public BooleanProperty pickerShowingProperty() { return pickerShowingProperty; }
+    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+    public boolean isPickerShowing() { return pickerShowingProperty.get(); }
+    public void setPickerShowing(boolean value) { pickerShowingProperty.set(value); }
 	// ==================================================================================================================
 	// SUPPORT
 }

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTextField.java
@@ -1,7 +1,7 @@
 /**
  * LocalDateTextField.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -190,6 +190,36 @@ public class LocalDateTextField extends Control
 	public void setText(String value) { textObjectProperty.set(value); }
 	public LocalDateTextField withText(String value) { setText(value); return this; }
 
+        
+        final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+
+   /**
+     * Represents the current state of the Picker popup, and whether it is
+     * currently visible on screen.
+     *
+     * @return
+     */
+    public BooleanProperty pickerShowingProperty() {
+        return pickerShowingProperty;
+    }
+
+    /**
+     * Allow to show/hide the Picker.
+     *
+     * @param value
+     */
+    public void setPickerShowing(boolean value) {
+        pickerShowingProperty.set(value);
+    }
+
+    /**
+     * Return true if the Picker is currently shown.
+     *
+     * @return
+     */
+    public boolean isPickerShowing() {
+        return pickerShowingProperty.get();
+    }
 	// ==================================================================================================================
 	// SUPPORT
 }

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTimeTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTimeTextField.java
@@ -188,35 +188,14 @@ public class LocalDateTimeTextField extends Control
 	public LocalDateTimeTextField withText(String value) { setText(value); return this; }
 	
         
-         final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
-
-    /**
+         /**
      * Represents the current state of the Picker popup, and whether it is
      * currently visible on screen.
-     *
-     * @return
      */
-    public BooleanProperty pickerShowingProperty() {
-        return pickerShowingProperty;
-    }
-
-    /**
-     * Allow to show/hide the Picker.
-     *
-     * @param value
-     */
-    public void setPickerShowing(boolean value) {
-        pickerShowingProperty.set(value);
-    }
-
-    /**
-     * Return true if the Picker is currently shown.
-     *
-     * @return
-     */
-    public boolean isPickerShowing() {
-        return pickerShowingProperty.get();
-    }
+    public BooleanProperty pickerShowingProperty() { return pickerShowingProperty; }
+    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+    public boolean isPickerShowing() { return pickerShowingProperty.get(); }
+    public void setPickerShowing(boolean value) { pickerShowingProperty.set(value); }
 	// ==================================================================================================================
 	// SUPPORT
 }

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTimeTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalDateTimeTextField.java
@@ -1,7 +1,7 @@
 /**
  * LocalDateTimeTextField.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -187,6 +187,36 @@ public class LocalDateTimeTextField extends Control
 	public void setText(String value) { textObjectProperty.set(value); }
 	public LocalDateTimeTextField withText(String value) { setText(value); return this; }
 	
+        
+         final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+
+    /**
+     * Represents the current state of the Picker popup, and whether it is
+     * currently visible on screen.
+     *
+     * @return
+     */
+    public BooleanProperty pickerShowingProperty() {
+        return pickerShowingProperty;
+    }
+
+    /**
+     * Allow to show/hide the Picker.
+     *
+     * @param value
+     */
+    public void setPickerShowing(boolean value) {
+        pickerShowingProperty.set(value);
+    }
+
+    /**
+     * Return true if the Picker is currently shown.
+     *
+     * @return
+     */
+    public boolean isPickerShowing() {
+        return pickerShowingProperty.get();
+    }
 	// ==================================================================================================================
 	// SUPPORT
 }

--- a/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalTimeTextField.java
+++ b/jfxtras-controls/src/main/java/jfxtras/scene/control/LocalTimeTextField.java
@@ -1,7 +1,7 @@
 /**
  * LocalTimeTextField.java
  *
- * Copyright (c) 2011-2014, JFXtras
+ * Copyright (c) 2011, 2015 JFXtras
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -34,9 +34,11 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Locale;
+import javafx.beans.property.BooleanProperty;
 
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
@@ -150,7 +152,14 @@ public class LocalTimeTextField extends Control
 	public void setParseErrorCallback(Callback<Throwable, Void> value) { this.parseErrorCallbackObjectProperty.setValue(value); }
 	public LocalTimeTextField withParseErrorCallback(Callback<Throwable, Void> value) { setParseErrorCallback(value); return this; }
 
-	
+    /**
+     * Represents the current state of the Picker popup, and whether it is
+     * currently visible on screen.
+     */
+    public BooleanProperty pickerShowingProperty() { return pickerShowingProperty; }
+    final private BooleanProperty pickerShowingProperty = new SimpleBooleanProperty();
+    public boolean isPickerShowing() { return pickerShowingProperty.get(); }
+    public void setPickerShowing(boolean value) { pickerShowingProperty.set(value); }
 	// ==================================================================================================================
 	// SUPPORT
 }

--- a/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarTextFieldTest.java
+++ b/jfxtras-controls/src/test/java/jfxtras/scene/control/test/CalendarTextFieldTest.java
@@ -89,6 +89,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 	{
 		// default value is null
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 		
 		// open the popup
 		click(".icon");
@@ -99,6 +100,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		
 		// now should be the value in the textfield
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 	/**
@@ -115,6 +117,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		
 		// default value is null
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 		
 		// open the popup
 		click(".icon");
@@ -128,6 +131,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		
 		// now should be the value in the textfield
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 	/**
@@ -138,16 +142,23 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 	{
 		// default value is null
 		Assert.assertNull(calendarTextField.getCalendar());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 		
 		// open the popup
 		click(".icon");
-		
+                
+                //The popup should be displayed.
+		Assert.assertTrue(calendarTextField.isPickerShowing());
+                
 		// click today
 		click(".today");
 		
 		// now should be the value in the textfield
 		Assert.assertEquals(TestUtil.quickFormatCalendarAsDate(Calendar.getInstance()), TestUtil.quickFormatCalendarAsDate(calendarTextField.getCalendar()));
-	}
+                
+                //The popup should be hidden.
+		Assert.assertFalse(calendarTextField.isPickerShowing());
+        }
 
 	/**
 	 * 
@@ -168,6 +179,9 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// open the popup
 		click(".icon");
 		Assert.assertTrue(find(".text-field").isDisabled());
+                
+                //The popup should be displayed.
+		Assert.assertTrue(calendarTextField.isPickerShowing());
 		
 		// click today
 		click(".today");
@@ -178,6 +192,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// now should be the value in the textfield
 		Assert.assertEquals(TestUtil.quickFormatCalendarAsDate(Calendar.getInstance()), TestUtil.quickFormatCalendarAsDate(calendarTextField.getCalendar()));
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 	/**
@@ -199,6 +214,9 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// open the popup
 		click(".icon");
 		Assert.assertTrue(find(".text-field").isDisabled());
+                
+                //The popup should be displayed.
+		Assert.assertTrue(calendarTextField.isPickerShowing());
 		
 		// click today
 		click(".today");
@@ -209,6 +227,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// should still be null
 		Assert.assertNull(calendarTextField.getCalendar());
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 	/**
@@ -230,6 +249,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// open the popup
 		click(".icon");
 		Assert.assertTrue(find(".text-field").isDisabled());
+		Assert.assertTrue(calendarTextField.isPickerShowing());
 		
 		// click today
 		click(".today");
@@ -240,6 +260,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// should still be null
 		Assert.assertNull(calendarTextField.getCalendar());
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 
@@ -262,6 +283,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// open the popup
 		click(".icon");
 		Assert.assertTrue(find(".text-field").isDisabled());
+                Assert.assertTrue(calendarTextField.isPickerShowing());
 		
 		// click today
 		click(".today");
@@ -272,6 +294,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		// should still be null
 		Assert.assertNull(calendarTextField.getCalendar());
 		Assert.assertFalse(find(".text-field").isDisabled());
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 	/**
@@ -289,6 +312,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		
 		// open the popup
 		click(".icon");
+                Assert.assertTrue(calendarTextField.isPickerShowing());
 
 		// assert that the popup shows January 1st 2013 
 		Assert.assertTrue( ((ToggleButton)find("#2013-01-01")).isSelected() );
@@ -304,9 +328,11 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 	{
 		// popup should be closed
 		assertPopupIsNotVisible(find(".text-field"));
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 		
 		// open the popup
 		click(".icon");
+                Assert.assertTrue(calendarTextField.isPickerShowing());
 		
 		// popup should be open
 		assertPopupIsVisible(find(".text-field"));
@@ -316,6 +342,7 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		
 		// popup should be closed
 		assertPopupIsNotVisible(find(".text-field"));
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 
 
@@ -492,17 +519,49 @@ public class CalendarTextFieldTest extends JFXtrasGuiTest {
 		
 		// popup should be closed
 		assertPopupIsNotVisible(find(".text-field"));
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 		
 		// open the popup
 		click(".icon");
 		
 		// popup should be closed
 		assertPopupIsVisible(find(".text-field"));
+                Assert.assertTrue(calendarTextField.isPickerShowing());
 		
 		// reselect 1st of January
 		click("#2013-01-01");
 		
 		// popup should be closed
 		assertPopupIsNotVisible(find(".text-field"));
+                Assert.assertFalse(calendarTextField.isPickerShowing());
+	}
+        
+        /**
+	 * 
+	 */
+	@Test
+	public void openPopupAndCloseWithProperty()
+	{
+		// popup should be closed
+		assertPopupIsNotVisible(find(".text-field"));
+                Assert.assertFalse(calendarTextField.isPickerShowing());
+		
+		// open the popup
+                TestUtil.runThenWaitForPaintPulse( () -> {
+			calendarTextField.setPickerShowing(true);
+		});
+                
+		// popup should be open
+		assertPopupIsVisible(find(".text-field"));
+                Assert.assertTrue(calendarTextField.isPickerShowing());
+		
+		// Close the popup
+                TestUtil.runThenWaitForPaintPulse( () -> {
+			calendarTextField.setPickerShowing(false);
+		});
+		
+		// popup should be closed
+		assertPopupIsNotVisible(find(".text-field"));
+                Assert.assertFalse(calendarTextField.isPickerShowing());
 	}
 }


### PR DESCRIPTION
Adding "pickerShowing" property on all TextFields in order to control more closely the popup display.

I've added the property on all TextFields files.

The popup is created only when necessary.

I've added some `Assert` tests when the popup is displayed. I also added one test when I display the popup via the property. Is that allright? 
