### PR TITLE
Fix to allow double click action on Appointment when AllowDragging is false

### DIFF
--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
@@ -141,15 +141,15 @@ abstract class AppointmentAbstractPane extends Pane {
 			// we handle this event
 			mouseEvent.consume();
 
-			// is dragging allowed
-			if (layoutHelp.skinnable.getAllowDragging() == false) {
-				handleSelect(mouseEvent);
-				return;
-			}
-
 			// if this an action
 			if (mouseEvent.getClickCount() > 1) {
 				handleAction();
+				return;
+			}
+
+			// is dragging allowed
+			if (layoutHelp.skinnable.getAllowDragging() == false) {
+				handleSelect(mouseEvent);
 				return;
 			}
 


### PR DESCRIPTION
When AllowDragging is set to false on Agenda the ActionCallBack on the Agenda can never be called on double click because the method returns before the double click is handled. Resolved this by moving the double click code to before the return on allowDragging check. This will not influence current dragging functionality.
