### PR TITLE
Remove extra day from LocalDateTimeRange when localDateTimeRangeCallb…

### DIFF
--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AgendaSkinTimeScale24HourAbstract.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AgendaSkinTimeScale24HourAbstract.java
@@ -182,7 +182,7 @@ implements AgendaSkin
 		LocalDate lStartLocalDate = lLocalDates.get(0);
 		LocalDate lEndLocalDate = lLocalDates.get(lLocalDates.size() - 1);
 		if (getSkinnable().getLocalDateTimeRangeCallback() != null) {
-			Agenda.LocalDateTimeRange lRange = new Agenda.LocalDateTimeRange(lStartLocalDate.atStartOfDay(), lEndLocalDate.plusDays(1).atStartOfDay());
+			Agenda.LocalDateTimeRange lRange = new Agenda.LocalDateTimeRange(lStartLocalDate.atStartOfDay(), lEndLocalDate.atStartOfDay());
 			getSkinnable().getLocalDateTimeRangeCallback().call(lRange);
 		}
 		if (getSkinnable().getCalendarRangeCallback() != null) {


### PR DESCRIPTION
…ack is executed

The extra day caused some unnecessary extra appointments to be created
when making appointments from a repeat rule.
