### PR TITLE
drawn and dragged appointment callbacks

### DIFF
--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
@@ -251,6 +251,12 @@ abstract class AppointmentAbstractPane extends Pane {
 			if (dragDropDateTime != null) { // not dropped somewhere outside
 				handleDrag(appointment, dragPickupDateTime, dragDropDateTime);					
 				
+                // has the client done his own popup?
+               Callback<Appointment, Void> lDragCallback = layoutHelp.skinnable.getDragAppointmentCallback();
+               if (lDragCallback != null) {
+                   lDragCallback.call(appointment);
+               }
+               
 				// relayout whole week
 				layoutHelp.skin.setupAppointments();
 			}

--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DayBodyPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DayBodyPane.java
@@ -42,6 +42,7 @@ import javafx.scene.Cursor;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
 import javafx.scene.shape.Rectangle;
+import javafx.util.Callback;
 import jfxtras.internal.scene.control.skin.DateTimeToCalendarHelper;
 import jfxtras.internal.scene.control.skin.agenda.AllAppointments;
 import jfxtras.scene.control.agenda.Agenda;
@@ -184,6 +185,11 @@ class DayBodyPane extends Pane
 			if (lAppointment != null) {
 				layoutHelp.skinnable.appointments().add(lAppointment); // the appointments collection is listened to, so they will automatically be refreshed
 			}
+	          // has the client done his own popup?
+            Callback<Appointment, Void> lDrawnCallback = layoutHelp.skinnable.getDrawnAppointmentCallback();
+            if (lDrawnCallback != null) {
+                lDrawnCallback.call(lAppointment);
+            }
 		});
 	}
 	private Rectangle resizeRectangle = null;

--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -47,7 +47,6 @@ import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
 import javafx.util.Callback;
 import jfxtras.internal.scene.control.skin.DateTimeToCalendarHelper;
-import jfxtras.internal.scene.control.skin.agenda.AgendaDaysFromDisplayedSkin;
 import jfxtras.internal.scene.control.skin.agenda.AgendaSkin;
 import jfxtras.internal.scene.control.skin.agenda.AgendaWeekSkin;
 
@@ -348,7 +347,30 @@ public class Agenda extends Control
 	public Callback<Appointment, Void> getEditAppointmentCallback() { return this.editAppointmentCallbackObjectProperty.getValue(); }
 	public void setEditAppointmentCallback(Callback<Appointment, Void> value) { this.editAppointmentCallbackObjectProperty.setValue(value); }
 	public Agenda withEditAppointmentCallback(Callback<Appointment, Void> value) { setEditAppointmentCallback(value); return this; }
-	
+
+    /** drawnAppointmentCallback:
+     * Agenda has a no popup appear after a new appointment is drawn, but maybe
+     * you want to do something yourself.  If so, you need to set this callback method and open your own window.
+     */
+    public ObjectProperty<Callback<Appointment, Void>> drawnAppointmentCallbackProperty() { return drawnAppointmentCallbackObjectProperty; }
+    final private ObjectProperty<Callback<Appointment, Void>> drawnAppointmentCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "editAppointmentCallback", null);
+    public Callback<Appointment, Void> getDrawnAppointmentCallback() { return this.drawnAppointmentCallbackObjectProperty.getValue(); }
+    public void setDrawnAppointmentCallback(Callback<Appointment, Void> value) { this.drawnAppointmentCallbackObjectProperty.setValue(value); }
+    public Agenda withDrawnAppointmentCallback(Callback<Appointment, Void> value) { setDrawnAppointmentCallback(value); return this; }
+
+    /** dragAppointmentCallback:
+     * This callback can have two functions.  First, it can be used to maintain the client domain
+     * consistent with the dragging time/date change.  This is necessary because the change listener
+     * only fires on deletions or additions, not on edit changes to its elements.
+     * Second, a popup can appear after a repeatable appointment is dragged to prompt a user if the 
+     * change is change is for one, this-and-future or all events.
+     */
+    public ObjectProperty<Callback<Appointment, Void>> dragAppointmentCallbackProperty() { return dragAppointmentCallbackObjectProperty; }
+    final private ObjectProperty<Callback<Appointment, Void>> dragAppointmentCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "editAppointmentCallback", null);
+    public Callback<Appointment, Void> getDragAppointmentCallback() { return this.dragAppointmentCallbackObjectProperty.getValue(); }
+    public void setDragAppointmentCallback(Callback<Appointment, Void> value) { this.dragAppointmentCallbackObjectProperty.setValue(value); }
+    public Agenda withDragAppointmentCallback(Callback<Appointment, Void> value) { setDragAppointmentCallback(value); return this; }
+    
 	/** actionCallback:
 	 * This triggered when the action is called on an appointment, usually this is a double click
 	 */


### PR DESCRIPTION
NEW APPOINTMENT DRAWN CALLBACK
I want a callback after a new appointment is drawn.   The callback will be used to make a popup for simple editing and provide buttons to advanced editing.  Similar popups exist in popular calendars like Google and Yahoo.

DRAGGED APPOINTMENT CALLBACK
Normally, I update the VComponents list when changes to appointments occur through a listener.  But, the listener doesn't fire when an individual appointment is edited.  I handle updating the VComponents through the edit popup, but I have no way to do so when an appointment is dragged to a new time.  Therefore, I need a callback for dragging appointments to update the VComponents.
