### PR TITLE
added appointmentChangedCallback

### DIFF
--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
@@ -249,9 +249,15 @@ abstract class AppointmentAbstractPane extends Pane {
 			// determine start and end DateTime of the drag
 			LocalDateTime dragDropDateTime = layoutHelp.skin.convertClickInSceneToDateTime(mouseEvent.getSceneX(), mouseEvent.getSceneY());
 			if (dragDropDateTime != null) { // not dropped somewhere outside
-				handleDrag(appointment, dragPickupDateTime, dragDropDateTime);					
+				handleDrag(appointment, dragPickupDateTime, dragDropDateTime);
 				
-				// relayout whole week
+                // has the client added a callback to process the change?
+                Callback<Appointment, Void> lChangedCallback = layoutHelp.skinnable.getAppointmentChangedCallback();
+                if (lChangedCallback != null) {
+                    lChangedCallback.call(appointment);
+                }
+                
+                // relayout whole week
 				layoutHelp.skin.setupAppointments();
 			}
 		});

--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DurationDragger.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DurationDragger.java
@@ -36,6 +36,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
+import javafx.util.Callback;
 import jfxtras.scene.control.agenda.Agenda.Appointment;
 import jfxtras.util.NodeUtil;
 
@@ -138,6 +139,12 @@ class DurationDragger extends Rectangle
 			
 			// set the new enddate
 			appointmentPane.appointment.setEndLocalDateTime(endLocalDateTime);
+
+            // has the client added a callback to process the change?
+            Callback<Appointment, Void> lChangedCallback = layoutHelp.skinnable.getAppointmentChangedCallback();
+            if (lChangedCallback != null) {
+                lChangedCallback.call(appointment);
+            }
 			
 			// relayout the entire skin
 			layoutHelp.skin.setupAppointments();

--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -348,7 +348,19 @@ public class Agenda extends Control
 	public Callback<Appointment, Void> getEditAppointmentCallback() { return this.editAppointmentCallbackObjectProperty.getValue(); }
 	public void setEditAppointmentCallback(Callback<Appointment, Void> value) { this.editAppointmentCallbackObjectProperty.setValue(value); }
 	public Agenda withEditAppointmentCallback(Callback<Appointment, Void> value) { setEditAppointmentCallback(value); return this; }
-	
+
+   /** appointmentChangedCallback:
+     * When an appointment is changed by Agenda (e.g. drag-n-drop to new time) change listeners will not fire.
+     * To enable the client to process those changes this callback can be used.  Additionally, for a repeatable
+     * appointment, this can be used to prompt the user if they want the change to occur to one, this-and-future
+     * or all events in series.
+     */
+    public ObjectProperty<Callback<Appointment, Void>> appointmentChangedCallbackProperty() { return appointmentChangedCallbackObjectProperty; }
+    final private ObjectProperty<Callback<Appointment, Void>> appointmentChangedCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "appointmentChangedCallback", null);
+    public Callback<Appointment, Void> getAppointmentChangedCallback() { return this.appointmentChangedCallbackObjectProperty.getValue(); }
+    public void setAppointmentChangedCallback(Callback<Appointment, Void> value) { this.appointmentChangedCallbackObjectProperty.setValue(value); }
+    public Agenda withAppointmentChangedCallback(Callback<Appointment, Void> value) { setAppointmentChangedCallback(value); return this; }
+
 	/** actionCallback:
 	 * This triggered when the action is called on an appointment, usually this is a double click
 	 */

--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -607,6 +607,30 @@ public class Agenda extends Control
 				 + this.getEndLocalDateTime()
 				 ;
 		}
+		
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if((obj == null) || (obj.getClass() != getClass())) {
+                return false;
+            }
+            AppointmentImplLocal testObj = (AppointmentImplLocal) obj;
+
+            boolean startEquals = getStartLocalDateTime().equals(testObj.getStartLocalDateTime());
+            boolean endEquals = getEndLocalDateTime().equals(testObj.getEndLocalDateTime());
+            boolean wholeDayEquals = isWholeDay().equals(testObj.isWholeDay());
+            boolean descriptionEquals = (getDescription() == null) ?
+                    (testObj.getDescription() == null) : getDescription().equals(testObj.getDescription());
+            boolean locationEquals = (getLocation() == null) ?
+                    (testObj.getLocation() == null) : getLocation().equals(testObj.getLocation());
+            boolean summaryEquals = (getSummary() == null) ?
+                    (testObj.getSummary() == null) : getSummary().equals(testObj.getSummary());
+            boolean appointmentGroupEquals = (getAppointmentGroup() == null) ?
+                    (testObj.getAppointmentGroup() == null) : getAppointmentGroup().equals(testObj.getAppointmentGroup());
+                    
+            return startEquals && endEquals && wholeDayEquals && descriptionEquals && locationEquals
+                    && summaryEquals && appointmentGroupEquals;
+        }
 	}
 	
 	/**


### PR DESCRIPTION
When an appointment is changed by Agenda (e.g. drag-n-drop to new time) change listeners will not fire.
To enable the client to process those changes this callback can be used.  Additionally, for a repeatable
appointment, this can be used to prompt the user if they want the change to occur to one, this-and-future
or all events in series.

No error in string this time.  I also shut off auto-import-reorganize to minimize changes.
