### PR TITLE
selectOneAppointmentCallback and appointmentBodyPaneMap

### DIFF
--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
@@ -356,6 +356,15 @@ abstract class AppointmentAbstractPane extends Pane {
 		// add to selection if not already added
 		if (layoutHelp.skinnable.selectedAppointments().contains(appointment) == false) {
 			layoutHelp.skinnable.selectedAppointments().add(appointment);
+			if (layoutHelp.skinnable.selectedAppointments().size() == 1)
+			{
+	            // has the client added a callback to process the change?
+	            System.out.println("select only one:");
+	            Callback<Appointment, Void> lSelectedCallback = layoutHelp.skinnable.getOneAppointmentSelectedCallback();
+	            if (lSelectedCallback != null) {
+	                lSelectedCallback.call(appointment);
+	            }
+			}
 		}
 		// pressing control allows to toggle
 		else if (mouseEvent.isControlDown()) {

--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
@@ -359,7 +359,6 @@ abstract class AppointmentAbstractPane extends Pane {
 			if (layoutHelp.skinnable.selectedAppointments().size() == 1)
 			{
 	            // has the client added a callback to process the change?
-	            System.out.println("select only one:");
 	            Callback<Appointment, Void> lSelectedCallback = layoutHelp.skinnable.getOneAppointmentSelectedCallback();
 	            if (lSelectedCallback != null) {
 	                lSelectedCallback.call(appointment);

--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/AppointmentAbstractPane.java
@@ -252,7 +252,7 @@ abstract class AppointmentAbstractPane extends Pane {
 				handleDrag(appointment, dragPickupDateTime, dragDropDateTime);
 				
                 // has the client added a callback to process the change?
-                Callback<Appointment, Void> lChangedCallback = layoutHelp.skinnable.getAppointmentChangedCallback();
+                Callback<Appointment, Void> lChangedCallback = layoutHelp.skinnable.getChangedAppointmentCallback();
                 if (lChangedCallback != null) {
                     lChangedCallback.call(appointment);
                 }
@@ -359,7 +359,7 @@ abstract class AppointmentAbstractPane extends Pane {
 			if (layoutHelp.skinnable.selectedAppointments().size() == 1)
 			{
 	            // has the client added a callback to process the change?
-	            Callback<Appointment, Void> lSelectedCallback = layoutHelp.skinnable.getOneAppointmentSelectedCallback();
+	            Callback<Appointment, Void> lSelectedCallback = layoutHelp.skinnable.getSelectOneAppointmentCallback();
 	            if (lSelectedCallback != null) {
 	                lSelectedCallback.call(appointment);
 	            }

--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DayBodyPane.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DayBodyPane.java
@@ -280,6 +280,7 @@ class DayBodyPane extends Pane
 			// create pane
 			AppointmentWholedayBodyPane lAppointmentPane = new AppointmentWholedayBodyPane(localDateObjectProperty.get(), lAppointment, layoutHelp);
 			wholedayAppointmentBodyPanes.add(lAppointmentPane);
+			layoutHelp.skinnable.appointmentBodyPaneMap().put(lAppointment, lAppointmentPane);
 			lAppointmentPane.setId(lAppointmentPane.getClass().getSimpleName() + localDateObjectProperty.get() + "/" + lCnt); // for testing
 			
 			// position by binding
@@ -311,6 +312,7 @@ class DayBodyPane extends Pane
 		for (Appointment lAppointment : taskAppointments) {
 			AppointmentTaskBodyPane lAppointmentPane = new AppointmentTaskBodyPane(lAppointment, layoutHelp);
 			taskAppointmentBodyPanes.add(lAppointmentPane);
+	        layoutHelp.skinnable.appointmentBodyPaneMap().put(lAppointment, lAppointmentPane);
 			lAppointmentPane.setId(lAppointmentPane.getClass().getSimpleName() + localDateObjectProperty.get() + "/" + lCnt); // for testing
 			
 			lCnt++;
@@ -336,6 +338,7 @@ class DayBodyPane extends Pane
 		for (Appointment lAppointment : regularAppointments) {
 			AppointmentRegularBodyPane lAppointmentPane = new AppointmentRegularBodyPane(localDateObjectProperty.get(), lAppointment, layoutHelp);
 			regularAppointmentBodyPanes.add(lAppointmentPane);
+			layoutHelp.skinnable.appointmentBodyPaneMap().put(lAppointment, lAppointmentPane);
 			lAppointmentPane.setId(lAppointmentPane.getClass().getSimpleName() + localDateObjectProperty.get() + "/" + lCnt); // for testing
 			
 			lCnt++;

--- a/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DurationDragger.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/internal/scene/control/skin/agenda/base24hour/DurationDragger.java
@@ -141,7 +141,7 @@ class DurationDragger extends Rectangle
 			appointmentPane.appointment.setEndLocalDateTime(endLocalDateTime);
 
             // has the client added a callback to process the change?
-            Callback<Appointment, Void> lChangedCallback = layoutHelp.skinnable.getAppointmentChangedCallback();
+            Callback<Appointment, Void> lChangedCallback = layoutHelp.skinnable.getChangedAppointmentCallback();
             if (lChangedCallback != null) {
                 lChangedCallback.call(appointment);
             }

--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -356,27 +356,27 @@ public class Agenda extends Control
 	public void setEditAppointmentCallback(Callback<Appointment, Void> value) { this.editAppointmentCallbackObjectProperty.setValue(value); }
 	public Agenda withEditAppointmentCallback(Callback<Appointment, Void> value) { setEditAppointmentCallback(value); return this; }
 
-   /** appointmentChangedCallback:
+   /** changedAppointmentCallback:
      * When an appointment is changed by Agenda (e.g. drag-n-drop to new time) change listeners will not fire.
      * To enable the client to process those changes this callback can be used.  Additionally, for a repeatable
      * appointment, this can be used to prompt the user if they want the change to occur to one, this-and-future
      * or all events in series.
      */
-    public ObjectProperty<Callback<Appointment, Void>> appointmentChangedCallbackProperty() { return appointmentChangedCallbackObjectProperty; }
-    final private ObjectProperty<Callback<Appointment, Void>> appointmentChangedCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "appointmentChangedCallback", null);
-    public Callback<Appointment, Void> getAppointmentChangedCallback() { return this.appointmentChangedCallbackObjectProperty.getValue(); }
-    public void setAppointmentChangedCallback(Callback<Appointment, Void> value) { this.appointmentChangedCallbackObjectProperty.setValue(value); }
-    public Agenda withAppointmentChangedCallback(Callback<Appointment, Void> value) { setAppointmentChangedCallback(value); return this; }
+    public ObjectProperty<Callback<Appointment, Void>> changedAppointmentCallbackProperty() { return changedAppointmentCallbackObjectProperty; }
+    final private ObjectProperty<Callback<Appointment, Void>> changedAppointmentCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "changedAppointmentCallback", null);
+    public Callback<Appointment, Void> getChangedAppointmentCallback() { return this.changedAppointmentCallbackObjectProperty.getValue(); }
+    public void setChangedAppointmentCallback(Callback<Appointment, Void> value) { this.changedAppointmentCallbackObjectProperty.setValue(value); }
+    public Agenda withChangedAppointmentCallback(Callback<Appointment, Void> value) { setChangedAppointmentCallback(value); return this; }
 
-    /** oneAppointmentSelectedCallback:
+    /** selectOneAppointmentCallback:
      * When one appointment is selected this callback is run.  It can be used to open a popup to provide edit,
      * delete or other edit options.
      */
-    public ObjectProperty<Callback<Appointment, Void>> oneAppointmentSelectedCallbackProperty() { return appointmentChangedCallbackObjectProperty; }
-    final private ObjectProperty<Callback<Appointment, Void>> oneAppointmentSelectedCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "oneAppointmentSelectedCallback", null);
-    public Callback<Appointment, Void> getOneAppointmentSelectedCallback() { return this.oneAppointmentSelectedCallbackObjectProperty.getValue(); }
-    public void setOneAppointmentSelectedCallback(Callback<Appointment, Void> value) { this.oneAppointmentSelectedCallbackObjectProperty.setValue(value); }
-    public Agenda withOneAppointmentSelectedCallback(Callback<Appointment, Void> value) { setOneAppointmentSelectedCallback(value); return this; }
+    public ObjectProperty<Callback<Appointment, Void>> selectOneAppointmentCallbackProperty() { return changedAppointmentCallbackObjectProperty; }
+    final private ObjectProperty<Callback<Appointment, Void>> selectOneAppointmentCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "selectOneAppointmentCallback", null);
+    public Callback<Appointment, Void> getSelectOneAppointmentCallback() { return this.selectOneAppointmentCallbackObjectProperty.getValue(); }
+    public void setSelectOneAppointmentCallback(Callback<Appointment, Void> value) { this.selectOneAppointmentCallbackObjectProperty.setValue(value); }
+    public Agenda withSelectOneAppointmentCallback(Callback<Appointment, Void> value) { setSelectOneAppointmentCallback(value); return this; }
 
 	/** actionCallback:
 	 * This triggered when the action is called on an appointment, usually this is a double click

--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -361,6 +361,16 @@ public class Agenda extends Control
     public void setAppointmentChangedCallback(Callback<Appointment, Void> value) { this.appointmentChangedCallbackObjectProperty.setValue(value); }
     public Agenda withAppointmentChangedCallback(Callback<Appointment, Void> value) { setAppointmentChangedCallback(value); return this; }
 
+    /** oneAppointmentSelectedCallback:
+     * When one appointment is selected this callback is run.  It can be used to open a popup to provide edit,
+     * delete or other edit options.
+     */
+    public ObjectProperty<Callback<Appointment, Void>> oneAppointmentSelectedCallbackProperty() { return appointmentChangedCallbackObjectProperty; }
+    final private ObjectProperty<Callback<Appointment, Void>> oneAppointmentSelectedCallbackObjectProperty = new SimpleObjectProperty<Callback<Appointment, Void>>(this, "oneAppointmentSelectedCallback", null);
+    public Callback<Appointment, Void> getOneAppointmentSelectedCallback() { return this.oneAppointmentSelectedCallbackObjectProperty.getValue(); }
+    public void setOneAppointmentSelectedCallback(Callback<Appointment, Void> value) { this.oneAppointmentSelectedCallbackObjectProperty.setValue(value); }
+    public Agenda withOneAppointmentSelectedCallback(Callback<Appointment, Void> value) { setOneAppointmentSelectedCallback(value); return this; }
+
 	/** actionCallback:
 	 * This triggered when the action is called on an appointment, usually this is a double click
 	 */

--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -36,6 +36,7 @@ import java.util.Calendar;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -45,6 +46,7 @@ import javafx.collections.ObservableList;
 import javafx.print.PrinterJob;
 import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
+import javafx.scene.layout.Pane;
 import javafx.util.Callback;
 import jfxtras.internal.scene.control.skin.DateTimeToCalendarHelper;
 import jfxtras.internal.scene.control.skin.agenda.AgendaDaysFromDisplayedSkin;
@@ -242,6 +244,11 @@ public class Agenda extends Control
             appointmentGroups().add(lAppointmentGroup);
         }
 	}
+	
+	/** Appointment body pane map: matches up Appointment to its body pane.  Used to place
+	 * popups when some callbacks are run */
+	public Map<Appointment, Pane> appointmentBodyPaneMap() { return appointmentBodyPaneMap; }
+	private Map<Appointment, Pane> appointmentBodyPaneMap = new WeakHashMap<>();
 
 	/** Locale: the locale is used to determine first-day-of-week, weekday labels, etc */
 	public ObjectProperty<Locale> localeProperty() { return localeObjectProperty; }


### PR DESCRIPTION
allows selecting just one appointment to run a callback, which opens a popup

populates a map in Agenda when appointment body panes are made.   Allows callbacks to match up Appointments to the body pane to position popups and set the owner node.
