### PR TITLE
change time zone to system default before getting LocalDateTime

### DIFF
--- a/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
+++ b/jfxtras-agenda/src/main/java/jfxtras/scene/control/agenda/Agenda.java
@@ -488,7 +488,7 @@ public class Agenda extends Control
 		
 		/** This is what Agenda uses to render the appointments */
 		default LocalDateTime getStartLocalDateTime() {
-			return getStartZonedDateTime().toLocalDateTime();
+			return getStartZonedDateTime().withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
 	    }
 		/** This is what Agenda uses to render the appointments */
 		default void setStartLocalDateTime(LocalDateTime v) {
@@ -497,7 +497,7 @@ public class Agenda extends Control
 		
 		/** This is what Agenda uses to render the appointments */
 		default LocalDateTime getEndLocalDateTime() {
-			return getEndZonedDateTime() == null ? null : getEndZonedDateTime().toLocalDateTime();
+			return getEndZonedDateTime() == null ? null : getEndZonedDateTime().withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
 	    }
 		/** End is exclusive */
 		default void setEndLocalDateTime(LocalDateTime v) {


### PR DESCRIPTION
Changing time zones adjusts the ZonedDateTime to user's time zone.  This
is important if an Appointment is entered in one time zone, but
displayed in a different one.  This change ensures the user sees the
events in the correct LocalDateTime instead of the one it was entered
in.
