### PR TITLE
Fixed Exception on Animation End

### DIFF
--- a/jfxtras-common/src/main/java/jfxtras/scene/layout/CircularPane.java
+++ b/jfxtras-common/src/main/java/jfxtras/scene/layout/CircularPane.java
@@ -584,7 +584,7 @@ public class CircularPane extends Pane {
 					    	transition = null;
 				    		getOnAnimateInFinished().handle(event);
 				    	}
-				    	if (transition.getRate() < 0 && getOnAnimateOutFinished() != null) {
+				    	else if (transition.getRate() < 0 && getOnAnimateOutFinished() != null) {
 					    	transition = null;
 				    		getOnAnimateOutFinished().handle(event);
 				    	}


### PR DESCRIPTION
Fixes a NullPointerException which could happen when setting an OnAnimateInFinished-Listener in the CircularPane