### PR TITLE
Removed compile scope from org.openjfx in jfxtras-controls because parent pom should define it

### DIFF
--- a/jfxtras-controls/pom.xml
+++ b/jfxtras-controls/pom.xml
@@ -55,17 +55,14 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Unrelated to #127, but similar in nature.